### PR TITLE
fix: add padding to page header text

### DIFF
--- a/my-app/src/Atoms/AboutPage/AboutPage.scss
+++ b/my-app/src/Atoms/AboutPage/AboutPage.scss
@@ -3,6 +3,8 @@
     flex-direction: column;
     align-items: center;
     padding-bottom: 64px;
+    padding-left: 16px;
+    padding-right: 16px;
     &--hero-page {
         padding-bottom: 0px;
     }


### PR DESCRIPTION
Before, when resizing the browser, the page header text would get too close to the borders of the
windows and become difficult to read. Now, this issue is solved.

"closes #16"